### PR TITLE
* 📈 Refactoring, lifecycle task, validationApi, README overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,18 @@
+# Gradle
+.gradle/
+build/
+!gradle/wrapper/gradle-wrapper.jar
+
+# IDE
+.idea/
+*.iml
+*.iws
+*.ipr
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Project
 /gradle.properties
+Dump-ProjectContent.ps1

--- a/README.md
+++ b/README.md
@@ -1,82 +1,59 @@
-# 🚀 YOJO Gradle Plugin
-**AsyncAPI → Java DTO Generator for Gradle**  
-✅ Multi-spec ✅ AsyncAPI v2.6/v3.0 ✅ Lombok ✅ Polymorphism ✅ Validation ✅ Enums with Descriptions
+# YOJO Gradle Plugin
+
+**AsyncAPI → Java DTO Generator for Gradle**
+
+✅ Multi-spec · ✅ AsyncAPI v2.6/v3.0 · ✅ Lombok · ✅ Polymorphism · ✅ Bean Validation · ✅ Enums with descriptions
 
 ![Yojo Banner](./yojo.png)
 
 [![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v?label=Gradle%20Plugin&metadataUrl=https%3A%2F%2Fplugins.gradle.org%2Fm2%2Fio%2Fgithub%2Fyojo-generator%2Fgradle-plugin%2Fio.github.yojo-generator.gradle-plugin.gradle.plugin%2Fmaven-metadata.xml)](https://plugins.gradle.org/plugin/io.github.yojo-generator.gradle-plugin)
-[![JDK 17+](https://img.shields.io/badge/JDK-17%2B-green.svg)](https://adoptium.net/)  
+[![JDK 17+](https://img.shields.io/badge/JDK-17%2B-green.svg)](https://adoptium.net/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE.md)
-[![AsyncAPI 2.0+](https://img.shields.io/badge/AsyncAPI-2.0%2F2.6%2F3.0-blue)](https://www.asyncapi.com)  
+[![AsyncAPI 2.0+](https://img.shields.io/badge/AsyncAPI-2.0%2F2.6%2F3.0-blue)](https://www.asyncapi.com)
 [![Status: Active](https://img.shields.io/badge/status-active-success)](https://github.com/yojo-generator/gradle-plugin)
 
 ---
 
-## ⚠️ Supported Specifications
-
-| Specification            | Status          | Notes                                                                     |
-|--------------------------|-----------------|---------------------------------------------------------------------------|
-| **AsyncAPI v2.0 / v2.6** | ✅ Full          | Primary target                                                            |
-| **AsyncAPI v3.0 (RC)**   | ✅ Experimental  | Supports `operations`, `channels`, `messages`, `payload: { schema: ... }` |
-| **OpenAPI 3.x**          | ❌ Not supported | Planned no earlier than 2026                                              |
-
-> 💡 Yojo is **AsyncAPI-only**. For OpenAPI, use [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator).
+- [Quick Start](#quick-start)
+- [How It Works](#how-it-works)
+- [Plugin DSL Reference](#plugin-dsl-reference)
+- [Generator Features (YAML)](#generator-features-yaml)
+- [Type Reference](#type-reference)
+- [Roadmap](#roadmap)
 
 ---
 
-## 📦 Installation
-Actual version: [![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v?label=Gradle%20Plugin&metadataUrl=https%3A%2F%2Fplugins.gradle.org%2Fm2%2Fio%2Fgithub%2Fyojo-generator%2Fgradle-plugin%2Fio.github.yojo-generator.gradle-plugin.gradle.plugin%2Fmaven-metadata.xml)](https://plugins.gradle.org/plugin/io.github.yojo-generator.gradle-plugin)
+## Quick Start
 
-### Groovy DSL (`build.gradle`)
+### 1. Apply the plugin
+
 ```groovy
+// build.gradle
 plugins {
-    id 'io.github.yojo-generator.gradle-plugin' version '1.1.2'
+    id 'io.github.yojo-generator.gradle-plugin' version '1.3.0'
 }
 ```
 
-### Kotlin DSL (`build.gradle.kts`)
 ```kotlin
+// build.gradle.kts
 plugins {
-    id("io.github.yojo-generator.gradle-plugin") version "1.1.2"
+    id("io.github.yojo-generator.gradle-plugin") version "1.3.0"
 }
 ```
 
----
+### 2. Configure
 
-## 🛠 Working Configuration
-
-### Groovy DSL (`build.gradle`)
 ```groovy
+// build.gradle
 yojo {
     configurations {
         create("main") {
             specificationProperties {
                 register("api") {
-                    specName("test.yaml")
-                    inputDirectory(layout.projectDirectory.dir("contract").asFile.absolutePath)
-                    outputDirectory(layout.buildDirectory.dir("generated/sources/yojo/com/example/api").get().asFile.absolutePath)
-                    packageLocation("com.example.api")
-                }
-                register("one-more-api") {
-                    specName("test.yaml")
-                    inputDirectory(layout.projectDirectory.dir("contract").asFile.absolutePath)
-                    outputDirectory(layout.buildDirectory.dir("generated/sources/yojo/oneMoreApi").get().asFile.absolutePath)
-                    packageLocation("oneMoreApi")
-                }
-            }
-            springBootVersion("3.2.0")
-            lombok {
-                enable(true)
-                allArgsConstructor(true)
-                noArgsConstructor(true)
-                accessors {
-                    enable(true)
-                    fluent(false)
-                    chain(true)
-                }
-                equalsAndHashCode {
-                    enable(true)
-                    callSuper(false)
+                    specName = "order-service.yaml"
+                    inputDirectory = layout.projectDirectory.dir("contract").asFile.absolutePath
+                    outputDirectory = layout.buildDirectory.dir("generated/sources/yojo/com/example/api").get().asFile.absolutePath
+                    packageLocation = "com.example.api"
                 }
             }
         }
@@ -92,30 +69,274 @@ tasks.compileJava {
 }
 ```
 
-### Kotlin DSL (`build.gradle.kts`)
-```kotlin
+### 3. Add an AsyncAPI contract
+
+```yaml
+# contract/order-service.yaml
+asyncapi: 2.6.0
+info:
+  title: Order Service
+  version: 1.0.0
+channels:
+  OrderCreated:
+    subscribe:
+      message:
+        payload:
+          $ref: '#/components/schemas/Order'
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        quantity:
+          type: integer
+          minimum: 1
+        email:
+          type: string
+          format: email
+```
+
+### 4. Generate
+
+```bash
+./gradlew generateClasses
+```
+
+Output:
+
+```
+build/generated/sources/yojo/com/example/api/
+├── common/
+│   └── Order.java
+└── messages/
+    └── OrderCreatedMessage.java
+```
+
+Generated `Order.java`:
+
+```java
+@Generated("Yojo")
+public class Order {
+
+    private String id;
+
+    @Min(1)
+    private Integer quantity;
+
+    @Email
+    private String email;
+}
+```
+
+---
+
+## How It Works
+
+The plugin is a thin Gradle wrapper around the [Yojo generator](https://github.com/yojo-generator/generator) (core library).
+
+```
+ ┌─────────────────────────────────────────────────────┐
+ │                    build.gradle                      │
+ │  yojo { configurations { ... } }                     │
+ └──────────────────────┬──────────────────────────────┘
+                        │
+                        ▼
+ ┌─────────────────────────────────────────────────────┐
+ │              Yojo Gradle Plugin                      │
+ │  - Reads DSL configuration                           │
+ │  - Creates named tasks (generateClasses, ...)        │
+ │  - Passes config to the generator                    │
+ └──────────────────────┬──────────────────────────────┘
+                        │
+                        ▼
+ ┌─────────────────────────────────────────────────────┐
+ │              Yojo Generator (core)                   │
+ │  - Parses AsyncAPI YAML                              │
+ │  - Resolves $refs, discriminator, polymorphism       │
+ │  - Resolves Java types, adds validation annotations  │
+ │  - Generates .java files                             │
+ └──────────────────────┬──────────────────────────────┘
+                        │
+                        ▼
+ ┌─────────────────────────────────────────────────────┐
+ │        Generated Java DTOs                           │
+ │  Order.java, Status.java, OrderCreatedMessage.java   │
+ └─────────────────────────────────────────────────────┘
+```
+
+**Key principle:** The plugin handles _where_ to read specs and _where_ to write output. The generator handles _what_ Java code to produce, driven entirely by your AsyncAPI YAML contract.
+
+---
+
+## Plugin DSL Reference
+
+Everything below is configured in `build.gradle` / `build.gradle.kts` inside the `yojo { }` block.
+
+### Task naming
+
+Each configuration registers a named task `generateClasses<Name>`:
+
+| Config name | Config task | Lifecycle task |
+|---|---|---|
+| `"main"` | `generateClassesMain` | `generateClasses` |
+| `"events"` | `generateClassesEvents` | `generateClasses` |
+| `"internal"` | `generateClassesInternal` | `generateClasses` |
+
+The **lifecycle task** `generateClasses` depends on all config tasks automatically.
+You only need `dependsOn("generateClasses")` — it always works, regardless of how
+many configurations you have:
+
+### `yojo { configurations { ... } }`
+
+```groovy
+yojo {
+    configurations {
+        create("main") {          // ← named configuration, becomes task name
+            specificationProperties { ... }   // required: at least one spec
+            validationApi("JAKARTA")          // optional: "JAKARTA" or "JAVAX"
+            // springBootVersion("3.2.0")    // legacy fallback
+            lombok { ... }                    // optional: Lombok settings
+        }
+    }
+}
+```
+
+### `specificationProperties { register("id") { ... } }`
+
+Each spec registration maps one YAML file to one output tree. Register multiple specs to generate from several contracts.
+
+| Field | Required | Type | Description | Example |
+|---|---|---|---|---|
+| `specName` | ✅ | `String` | YAML filename | `"order-service.yaml"` |
+| `inputDirectory` | ✅ | `String` | Absolute path to spec directory | `layout.projectDirectory.dir("contract").asFile.absolutePath` |
+| `outputDirectory` | ✅ | `String` | Absolute output root | `layout.buildDirectory.dir("...").get().asFile.absolutePath` |
+| `packageLocation` | ✅ | `String` | Base Java package | `"com.example.api"` |
+
+Generated package structure:
+
+```
+<outputDirectory>/com/example/api/
+├── common/      ← DTOs, enums, interfaces from components.schemas
+└── messages/    ← message payloads from channels
+```
+
+### `validationApi`
+
+Preferred way to select the validation annotation namespace:
+
+| Value | API | Example annotation |
+|---|---|---|
+| `"JAKARTA"` | `jakarta.validation.*` | `jakarta.validation.constraints.NotNull` |
+| `"JAVAX"` | `javax.validation.*` | `javax.validation.constraints.NotNull` |
+| omitted | `jakarta.validation.*` | (defaults to Jakarta) |
+
+### `springBootVersion` (legacy)
+
+Fallback when `validationApi` is not set. Uses version-based heuristic:
+
+| Value | API | Example annotation |
+|---|---|---|
+| `"3.0.0"` or higher | `jakarta.validation.*` | `jakarta.validation.constraints.NotNull` |
+| `"2.7.x"` or lower | `javax.validation.*` | `javax.validation.constraints.NotNull` |
+| omitted | `jakarta.validation.*` | (defaults to Jakarta) |
+
+> `validationApi` takes precedence. Only use `springBootVersion` if you need the version-based heuristic.
+
+### `lombok { ... }`
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `enable` | `boolean` | `true` | Adds `@Data` to generated classes |
+| `allArgsConstructor` | `boolean` | `false` | Adds `@AllArgsConstructor` |
+| `noArgsConstructor` | `boolean` | `true` | Adds `@NoArgsConstructor` |
+| `accessors { ... }` | closure | — | `@Accessors` configuration |
+| `equalsAndHashCode { ... }` | closure | — | `@EqualsAndHashCode` configuration |
+
+#### `accessors { ... }`
+
+| Option | Type | Default | Effect |
+|---|---|---|---|
+| `enable` | `boolean` | `false` | Generate `@Accessors` |
+| `fluent` | `boolean` | `false` | `obj.field(val)` instead of `obj.setField(val)` |
+| `chain` | `boolean` | `false` | Setters return `this` |
+
+#### `equalsAndHashCode { ... }`
+
+| Option | Type | Default | Effect |
+|---|---|---|---|
+| `enable` | `boolean` | `false` | Generate `@EqualsAndHashCode` |
+| `callSuper` | `boolean` | — | `callSuper = true` if set |
+
+### Complete DSL example
+
+```groovy
 yojo {
     configurations {
         create("main") {
             specificationProperties {
                 register("api") {
-                    specName.set("api.yaml")
-                    inputDirectory.set(layout.projectDirectory.dir("contract").asFile.absolutePath)
-                    outputDirectory.set(layout.buildDirectory.dir("generated/sources/yojo/api/com/example/api").get().asFile.absolutePath)
-                    packageLocation.set("com.example.api")
+                    specName = "order-service.yaml"
+                    inputDirectory = layout.projectDirectory.dir("contract").asFile.absolutePath
+                    outputDirectory = layout.buildDirectory
+                        .dir("generated/sources/yojo/com/example/api").get().asFile.absolutePath
+                    packageLocation = "com.example.api"
                 }
-                register("events-api") {
-                    specName.set("events.yaml")
-                    inputDirectory.set(layout.projectDirectory.dir("contract").asFile.absolutePath)
-                    outputDirectory.set(layout.buildDirectory.dir("generated/sources/yojo/events").get().asFile.absolutePath)
-                    packageLocation.set("events")
+                register("events") {
+                    specName = "events.yaml"
+                    inputDirectory = layout.projectDirectory.dir("contract").asFile.absolutePath
+                    outputDirectory = layout.buildDirectory
+                        .dir("generated/sources/yojo/io/example/events").get().asFile.absolutePath
+                    packageLocation = "io.example.events"
                 }
             }
+            validationApi("JAKARTA")
+            lombok {
+                enable = true
+                allArgsConstructor = false
+                noArgsConstructor = true
+                accessors {
+                    enable = true
+                    fluent = false
+                    chain = true
+                }
+                equalsAndHashCode {
+                    enable = true
+                    callSuper = false
+                }
+            }
+        }
+    }
+}
 
-            springBootVersion.set("3.2.0")
+sourceSets {
+    main.java.srcDir(layout.buildDirectory.dir("generated/sources/yojo"))
+}
+
+tasks.compileJava {
+    dependsOn("generateClasses")
+}
+```
+
+```kotlin
+// build.gradle.kts
+yojo {
+    configurations {
+        create("main") {
+            specificationProperties {
+                register("api") {
+                    specName.set("order-service.yaml")
+                    inputDirectory.set(layout.projectDirectory.dir("contract").asFile.absolutePath)
+                    outputDirectory.set(layout.buildDirectory
+                        .dir("generated/sources/yojo/com/example/api").get().asFile.absolutePath)
+                    packageLocation.set("com.example.api")
+                }
+            }
+            validationApi.set("JAKARTA")
             lombok {
                 enable.set(true)
-                allArgsConstructor.set(true)
+                allArgsConstructor.set(false)
                 noArgsConstructor.set(true)
                 accessors {
                     enable.set(true)
@@ -144,124 +365,495 @@ tasks.compileJava {
 }
 ```
 
-→ Output structure:
+---
+
+## Generator Features (YAML)
+
+All features below are controlled through your **AsyncAPI YAML contract**, not through the Gradle DSL. The plugin passes the YAML to the generator, which reads these attributes and produces the corresponding Java code.
+
+### 1. Fields and Types
+
+```yaml
+properties:
+  simpleString:
+    type: string                                         # → String
+  uuidField:
+    type: string
+    format: uuid                                         # → UUID
+  dateField:
+    type: string
+    format: date                                         # → LocalDate
+  dateTimeField:
+    type: string
+    format: date-time                                    # → OffsetDateTime
+  count:
+    type: integer                                        # → Integer
+  bigPrime:
+    type: integer
+    format: int64                                        # → Long
+  ratio:
+    type: number
+    format: big-decimal                                  # → BigDecimal
+  isActive:
+    type: boolean                                        # → Boolean
+  primitiveInt:
+    type: integer
+    primitive: true                                      # → int (not Integer)
 ```
-build/generated/sources/yojo/
-├── api/
-│   ├── common/      # DTOs, enums, interfaces
-│   └── messages/    # message payloads
-└── events-api/    # same structure
+
+### 2. Required fields and validation
+
+```yaml
+properties:
+  email:
+    type: string
+    format: email                                        # → @Email
+    required: [email]                                    # → @NotBlank on strings
+  age:
+    type: integer
+    minimum: 0
+    maximum: 150                                         # → @Min(0) @Max(150)
+  description:
+    type: string
+    minLength: 10
+    maxLength: 1000                                      # → @Size(min=10, max=1000)
+  code:
+    type: string
+    pattern: "^[A-Z]{3}-\\d{4}$"                         # → @Pattern(regexp="...")
+  price:
+    type: number
+    format: big-decimal
+    multipleOf: 0.01                                     # → @Digits(integer=1, fraction=2)
+```
+
+### 3. Collections
+
+```yaml
+properties:
+  tags:
+    type: array
+    items:
+      type: string                                       # → List<String>
+      x-realization: ArrayList                           # → = new ArrayList<>()
+  uniqueIds:
+    type: array
+    format: set
+    items:
+      type: integer                                      # → Set<Integer>
+      x-realization: HashSet                             # → = new HashSet<>()
+  matrix:
+    type: array
+    items:
+      type: array
+      items:
+        type: number                                     # → List<List<BigDecimal>>
+```
+
+### 4. Maps
+
+```yaml
+properties:
+  metadata:
+    type: object
+    additionalProperties:
+      type: string                                       # → Map<String, String>
+  config:
+    type: object
+    format: uuid
+    additionalProperties:
+      type: integer                                      # → Map<UUID, Integer>
+  nested:
+    type: object
+    additionalProperties:
+      type: array
+      format: set
+      items:
+        type: string                                     # → Map<String, Set<String>>
+```
+
+### 5. Enums
+
+Enums can be defined in two ways:
+
+**A. Standalone schema enum** — generates a top-level Java enum class:
+
+```yaml
+components:
+  schemas:
+    Status:
+      type: object
+      enum: [PENDING, CONFIRMED, SHIPPED]
+```
+```java
+public enum Status { PENDING, CONFIRMED, SHIPPED }
+```
+
+**B. Property-level enum** — generates an inner enum class (named `ParentProperty`):
+
+```yaml
+properties:
+  status:
+    type: string
+    enum: [PENDING, CONFIRMED, SHIPPED]    # → OrderStatus enum class
 ```
 
 ---
 
-## 📋 Configuration Attributes Reference
+**Enum with descriptions** (`x-enumNames`):
 
-### Top-level: `yojo { }`
+```yaml
+Result:
+  type: object
+  enum: [SUCCESS, FAILURE]
+  x-enumNames:
+    SUCCESS: "Operation completed successfully"
+    FAILURE: "Operation failed"
+```
+```java
+public enum Result {
+    SUCCESS("Operation completed successfully"),
+    FAILURE("Operation failed");
+    // + getValue()
+}
+```
 
-| Attribute        | Type                                     | Description                                  |
-|------------------|------------------------------------------|----------------------------------------------|
-| `configurations` | `NamedDomainObjectContainer<YojoConfig>` | Container for independent generation configs |
+**Enum with wire values** (`x-enumValues` + optional `x-enumDefault`):
+
+```yaml
+OrderStatus:
+  type: object
+  enum: [PENDING, CONFIRMED, CANCELLED]
+  x-enumValues:
+    PENDING: "P"
+    CONFIRMED: "C"
+    CANCELLED: "X"
+  x-enumDefault: true          # adds UNKNOWN_DEFAULT_YOJO fallback
+```
+```java
+public enum OrderStatus {
+    PENDING("P"),
+    CONFIRMED("C"),
+    CANCELLED("X"),
+    UNKNOWN_DEFAULT_YOJO("UNKNOWN");
+
+    @JsonValue
+    public String getValue() { return value; }
+
+    @JsonCreator
+    public static OrderStatus fromValue(String value) {
+        for (OrderStatus v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        return UNKNOWN_DEFAULT_YOJO;  // instead of throwing
+    }
+}
+```
+
+### 6. Polymorphism (`oneOf` / `allOf`)
+
+```yaml
+# Property-level: all schemas merged into one class
+polymorph:
+  oneOf:
+    - $ref: '#/components/schemas/StatusOnly'
+    - $ref: '#/components/schemas/StatusWithCode'         # → PolymorphStatusOnlyStatusWithCode
+
+# Schema-level: merged with root properties taking priority
+MySchema:
+  allOf:
+    - $ref: '#/components/schemas/Base'
+    - type: object
+      properties:
+        extraField:
+          type: string
+```
+
+### 7. Discriminator (Jackson `@JsonTypeInfo` / `@JsonSubTypes`)
+
+```yaml
+Pet:
+  type: object
+  discriminator: petType
+  properties:
+    name:
+      type: string
+    petType:
+      type: string
+
+Cat:
+  allOf:
+    - $ref: '#/components/schemas/Pet'
+  properties:
+    huntingSkill:
+      type: string
+
+# Custom discriminator value via const
+StickInsect:
+  allOf:
+    - $ref: '#/components/schemas/Pet'
+    - type: object
+      properties:
+        petType:
+          const: StickBug    # → @JsonSubTypes.Type(value = StickInsect.class, name = "StickBug")
+        color:
+          type: string
+```
+
+Generated Java:
+
+```java
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY,
+              property = "petType", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Cat.class, name = "Cat"),
+    @JsonSubTypes.Type(value = StickInsect.class, name = "StickBug")
+})
+public class Pet { ... }
+public class Cat extends Pet { ... }
+public class StickInsect extends Pet { ... }
+```
+
+### 8. Final fields (`x-final`)
+
+```yaml
+ImmutableDto:
+  type: object
+  properties:
+    createdAt:
+      type: string
+      format: date-time
+      x-final: true              # → private final OffsetDateTime createdAt;
+    name:
+      type: string               # → private String name; (regular mutable field)
+```
+
+- Fields with `x-final: true` are declared `final` and have **no setter**
+- A constructor is generated for all final fields
+- `@NoArgsConstructor` is automatically skipped when uninitialized finals exist
+- If `default` is also set: `private final Type field = defaultValue;`
+
+### 9. Inheritance and interfaces
+
+```yaml
+# Extend a superclass
+UserDto:
+  type: object
+  x-extends:
+    x-from-class: BaseEntity
+    x-from-package: com.example.base
+  properties:
+    name:
+      type: string               # → public class UserDto extends BaseEntity { ... }
+
+# Implement interfaces
+Validatable:
+  type: object
+  x-implements:
+    x-from-interface:
+      - com.example.api.Validatable
+      - java.io.Serializable     # → public class X implements Validatable, Serializable { ... }
+
+# Define an interface (no implementation)
+MyService:
+  type: object
+  format: interface
+  x-methods:
+    doWork:
+      description: "Performs work"
+      x-definition: "void doWork();"
+  x-imports:
+    - com.example.Domain        # → import com.example.Domain;
+```
+
+### 10. Custom annotations
+
+```yaml
+# Class-level annotations
+MySchema:
+  type: object
+  x-class-annotation:
+    - com.example.MyAnnotation
+    - com.example.WithParam("value")
+  properties: ...
+
+# Field-level annotations
+MySchema:
+  type: object
+  properties:
+    myField:
+      type: string
+      x-field-annotation:
+        - com.example.MyFieldAnnotation
+```
+
+### 11. Existing types (reference external classes)
+
+```yaml
+properties:
+  author:
+    type: object
+    format: existing
+    name: User
+    package: com.example.domain    # → private User author; + import com.example.domain.User;
+```
+
+### 12. Validation groups
+
+```yaml
+MySchema:
+  type: object
+  x-validation-groups: [Create.class, Update.class]
+  x-validation-groups-imports:
+    - com.example.validation.Create
+    - com.example.validation.Update
+  x-validate-by-groups: [email, name]
+  properties:
+    email:
+      type: string                 # → @NotBlank(groups = {Create.class, Update.class})
+    name:
+      type: string                 # → @NotBlank(groups = {Create.class, Update.class})
+    age:
+      type: integer                # → no group annotation (not in validate-by list)
+```
+
+### 13. Messages
+
+```yaml
+channels:
+  OrderCreated:
+    subscribe:
+      message:
+        payload:
+          $ref: '#/components/schemas/Order'
+
+  # Inline payload
+  UserRegistered:
+    subscribe:
+      message:
+        payload:
+          properties:
+            userId:
+              type: string
+
+  # Polymorphic message
+  Notification:
+    subscribe:
+      message:
+        payload:
+          oneOf:
+            - $ref: '#/components/schemas/EmailNotification'
+            - $ref: '#/components/schemas/SmsNotification'
+
+  # Custom message package
+  CustomEvent:
+    subscribe:
+      message:
+        payload:
+          pathForGenerateMessage: "io.github.events"
+          $ref: '#/components/schemas/EventPayload'
+```
+
+### 14. Attribute deprecation notice
+
+Legacy attribute names (without `x-` prefix) still work but log deprecation warnings:
+
+| Legacy (deprecated) | New (preferred) |
+|---|---|
+| `realization` | `x-realization` |
+| `digits` | `x-digits` |
+| `additionalFormat` | `x-additional-format` |
+| `validationGroups` | `x-validation-groups` |
+| `validationGroupsImports` | `x-validation-groups-imports` |
+| `validateByGroups` | `x-validate-by-groups` |
+| `extends` / `fromClass` / `fromPackage` | `x-extends` / `x-from-class` / `x-from-package` |
+| `implements` / `fromInterface` | `x-implements` / `x-from-interface` |
+| `lombok` | `x-lombok` (per-schema override) |
+| `methods` / `definition` | `x-methods` / `x-definition` |
+| `imports` | `x-imports` |
+| `removeSchema` | `x-remove-schema` |
+| `pathForGenerateMessage` | `x-path-for-generate-message` |
 
 ---
 
-### `configurations { create("name") { ... } }`
+## Type Reference
 
-| Attribute                 | Type                                                  | Required | Description                                           | Example                      |
-|---------------------------|-------------------------------------------------------|----------|-------------------------------------------------------|------------------------------|
-| `specificationProperties` | `NamedDomainObjectContainer<SpecificationProperties>` | ✅        | List of AsyncAPI specs to generate                    | `register("api") { ... }`    |
-| `springBootVersion(...)`  | `String`                                              | —        | Selects `jakarta` (≥3.0) or `javax` (≤2.7) validation | `springBootVersion("3.2.0")` |
-| `lombok { ... }`          | closure                                               | —        | Lombok configuration                                  | see below                    |
+### YAML → Java type mapping
 
----
+| YAML | Java | Import |
+|---|---|---|
+| `type: string` | `String` | — |
+| `type: string, format: uuid` / `type: object, format: uuid` | `UUID` | `java.util.UUID` |
+| `type: string, format: date` / `type: object, format: date` | `LocalDate` | `java.time.LocalDate` |
+| `type: string, format: date-time` / `type: object, format: date-time` | `OffsetDateTime` | `java.time.OffsetDateTime` |
+| `type: string, format: local-date-time` | `LocalDateTime` | `java.time.LocalDateTime` |
+| `type: string, format: simple-date` | `Date` | `java.util.Date` |
+| `type: string, format: email` | `String` + `@Email` | `jakarta.validation.constraints.Email` |
+| `type: string, format: uri` | `URI` | `java.net.URI` |
+| `type: integer` / `format: int32` | `Integer` | — |
+| `type: integer, format: int64` | `Long` | — |
+| `type: number, format: float` | `Float` | — |
+| `type: number, format: double` | `Double` | — |
+| `type: number` (bare) | `BigDecimal` | `java.math.BigDecimal` |
+| `type: number, format: big-decimal` | `BigDecimal` | `java.math.BigDecimal` |
+| `type: number, format: big-integer` | `BigInteger` | `java.math.BigInteger` |
+| `type: boolean` | `Boolean` | — |
+| `type: array` | `List<T>` | `java.util.List` |
+| `type: array, format: set` | `Set<T>` | `java.util.Set` |
+| `type: object, additionalProperties` | `Map<K, V>` | `java.util.Map` |
+| `type: object, properties: {...}` | Custom DTO class | generated |
 
-### `specificationProperties { register("id") { ... } }`
+### Validation annotations
 
-| Attribute              | Type     | Required | Description                                       | Example                                                                             |
-|------------------------|----------|----------|---------------------------------------------------|-------------------------------------------------------------------------------------|
-| `specName(...)`        | `String` | ✅        | Filename of AsyncAPI spec (`.yaml`, `.yml`)       | `specName("asyncapi.yaml")`                                                         |
-| `inputDirectory(...)`  | `String` | ✅        | Absolute path to spec directory                   | `layout.projectDirectory.dir("contract").asFile.absolutePath`                       |
-| `outputDirectory(...)` | `String` | ✅        | Absolute path to output root                      | `layout.buildDirectory.dir("generated/sources/yojo/api").get().asFile.absolutePath` |
-| `packageLocation(...)` | `String` | ✅        | Base Java package (without `.common`/`.messages`) | `packageLocation("com.example.api")`                                                |
+| YAML condition | Annotation |
+|---|---|
+| `required` + string | `@NotBlank` |
+| `required` + collection | `@NotEmpty` |
+| `required` + other | `@NotNull` |
+| `pattern: "..."` | `@Pattern(regexp = "...")` |
+| `minLength` / `maxLength` | `@Size(min = X, max = Y)` |
+| `minimum` / `maximum` | `@Min(X)` / `@Max(Y)` |
+| `multipleOf: 0.01` | `@Digits(integer = I, fraction = F)` |
+| `format: email` | `@Email` |
+| nested object (non-collection) | `@Valid` |
+| not required, no validation | `@Nullable` (configurable type) |
 
-> 📁 Generated packages:
-> - `com.example.api.common.*`
-> - `com.example.api.messages.*`
+### AsyncAPI version support
 
----
-
-### `lombok { ... }`
-
-| Attribute                   | Type      | Default | Description                    | Java Effect           |
-|-----------------------------|-----------|---------|--------------------------------|-----------------------|
-| `enable(...)`               | `boolean` | `true`  | Enable Lombok annotations      | `@Data`               |
-| `allArgsConstructor(...)`   | `boolean` | `false` | Generate `@AllArgsConstructor` | `@AllArgsConstructor` |
-| `noArgsConstructor(...)`    | `boolean` | `true`  | Generate `@NoArgsConstructor`  | `@NoArgsConstructor`  |
-| `accessors { ... }`         | closure   | —       | Configure `@Accessors`         | see below             |
-| `equalsAndHashCode { ... }` | closure   | —       | Configure `@EqualsAndHashCode` | see below             |
-
-#### `accessors { ... }`
-| Attribute     | Type      | Default | Description                                                       |
-|---------------|-----------|---------|-------------------------------------------------------------------|
-| `enable(...)` | `boolean` | `false` | Enable `@Accessors`                                               |
-| `fluent(...)` | `boolean` | `false` | `fluent = true` → `obj.field(val)` instead of `obj.setField(val)` |
-| `chain(...)`  | `boolean` | `false` | `chain = true` → setters return `this`                            |
-
-→ `@Accessors(fluent = false, chain = true)`
-
-#### `equalsAndHashCode { ... }`
-| Attribute        | Type      | Default | Description                                                       |
-|------------------|-----------|---------|-------------------------------------------------------------------|
-| `enable(...)`    | `boolean` | `false` | Enable `@EqualsAndHashCode`                                       |
-| `callSuper(...)` | `boolean` | `null`  | `callSuper = true/false` → `@EqualsAndHashCode(callSuper = true)` |
-
----
-
-## ✅ Supported AsyncAPI Features
-
-| Feature                      | YAML Example                                            | → Java                                           |
-|------------------------------|---------------------------------------------------------|--------------------------------------------------|
-| **`multipleOf: 0.01`**       | `multipleOf: 0.01`                                      | `@Digits(integer = 1, fraction = 2)`             |
-| **`realization: ArrayList`** | `items: { ..., realization: ArrayList }`                | `List<T> field = new ArrayList<>();`             |
-| **Enum + `x-enumNames`**     | `x-enumNames: { SUCCESS: "Ok" }`                        | `SUCCESS("Ok")` + `String getValue()`            |
-| **Enum case conversion**     | `enum: [success-case, "\r\n"]`                          | `SUCCESS_CASE`, `CARRIAGE_RETURN_LINE_FEED`      |
-| **`pathForGenerateMessage`** | `pathForGenerateMessage: 'io.github.events'`            | `package io.github.events;`                      |
-| **`removeSchema: true`**     | `payload: { $ref: X, removeSchema: true }`              | Only fields in message, no `X.java`              |
-| **Inheritance**              | `extends: { fromClass: BaseEntity }`                    | `class Dto extends BaseEntity { ... }`           |
-| **Interfaces**               | `format: interface`, `methods: [...]`                   | `interface Service { Type method(...); }`        |
-| **`format: existing`**       | `format: existing`, `name: User`, `package: com.domain` | `private User user;` + `import com.domain.User;` |
+| Version | Status | Notes |
+|---|---|---|
+| AsyncAPI 2.0 / 2.6 | ✅ Full | All features, `channels` → `publish`/`subscribe` → `message` → `payload` |
+| AsyncAPI 3.0 (RC) | ✅ Experimental | `operations` → `channel` → `messages` → `payload { schema { ... } }` |
+| OpenAPI 3.x | ❌ Not supported | Planned no earlier than 2026 |
 
 ---
 
-## 🗺 Roadmap
+## Roadmap
 
-| Feature                                                  | Status             |
-|----------------------------------------------------------|--------------------|
-| **Jackson annotations** (`@JsonProperty`, `@JsonFormat`) | ✅ In development   |
-| **AsyncAPI spec validation** (pre-generation)            | ✅ In development   |
-| **Lombok extensions** (`@Builder`, `@SuperBuilder`)      | ✅ In development   |
-| **OpenAPI 3.1 support**                                  | 🚧 Planned Q2 2026 |
+| Feature | Status |
+|---|---|
+| `x-` prefixed attributes (deprecation of legacy names) | ✅ Done (core 4.3.0) |
+| `x-final` immutable fields | ✅ Done (core 4.3.0) |
+| `@JsonTypeId` on discriminator fields | ✅ Done (core 4.3.0) |
+| Jackson annotations (`@JsonProperty`, `@JsonFormat`) | 🔄 In development |
+| AsyncAPI spec validation (pre-generation) | 🔄 In development |
+| Lombok extensions (`@Builder`, `@SuperBuilder`) | 🔄 In development |
+| Gradle configuration cache support | 📋 Planned |
+| OpenAPI 3.1 support | 📋 Planned Q2 2026 |
 
 ---
 
-## 📬 Contact
+## Contact
 
 - **Author**: Vladimir Morozkin
-- **📧 Email**: `jvmorozkin@gmail.com`
-- **📟 Telegram**: [`@vmorozkin`](https://t.me/vmorozkin)
+- **Email**: `jvmorozkin@gmail.com`
+- **Telegram**: [@vmorozkin](https://t.me/vmorozkin)
 - **GitHub**: [yojo-generator/gradle-plugin](https://github.com/yojo-generator/gradle-plugin)
+- **Core library**: [yojo-generator/generator](https://github.com/yojo-generator/generator)
 
-> 🙌 Send your AsyncAPI spec — I’ll help you integrate.  
-> 🐞 PRs and issues are welcome!
-
----
-
-## ⚖️ License
-
-Distributed under the **Apache License 2.0**.  
-See [LICENSE.md](LICENSE.md).
+> PRs, issues, and feedback are welcome. Send your AsyncAPI spec and I will help you integrate.
 
 ---
 
-🚀 **AsyncAPI → Java — fast, precise, zero manual work.**  
-Let’s generate some code!
+## License
+
+Distributed under the **Apache License 2.0**. See [LICENSE.md](LICENSE.md).

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'io.github.yojo-generator'
-version '1.2.0'
+version '1.3.0'
 
 allprojects {
     repositories {
@@ -19,7 +19,7 @@ allprojects {
 dependencies {
     implementation gradleApi()
     implementation localGroovy()
-    api 'io.github.yojo-generator:generator:4.0.0'
+    api 'io.github.yojo-generator:generator:4.3.0'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.5.2'
 }

--- a/src/main/groovy/ru/yojo/codegen/YojoConfig.java
+++ b/src/main/groovy/ru/yojo/codegen/YojoConfig.java
@@ -3,24 +3,18 @@ package ru.yojo.codegen;
 import groovy.lang.Closure;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.provider.ProviderFactory;
 import ru.yojo.codegen.meta.Configuration;
 
 import javax.inject.Inject;
-import java.util.ArrayList;
 
 public class YojoConfig {
     private final String name;
-    private final ProjectLayout layout;
     private final Configuration configuration;
 
     @Inject
-    public YojoConfig(String name, ProviderFactory providers, ObjectFactory objects, ProjectLayout layout) {
+    public YojoConfig(String name, ObjectFactory objects, ProjectLayout layout) {
         this.name = name;
-        this.layout = layout;
         this.configuration = objects.newInstance(Configuration.class, layout);
-        // Инициализация defaults
-        this.configuration.getSpecificationProperties().addAll(new ArrayList<>());
     }
 
     // DSL: specificationProperties { api { ... } }
@@ -29,7 +23,13 @@ public class YojoConfig {
         YojoConfig.applyClosureToDelegate(closure, configuration.getSpecificationProperties());
     }
 
-    // DSL: springBootVersion = "3.2.0", lombok { ... }, etc.
+    // DSL: validationApi("JAKARTA") — preferred way to select javax vs jakarta
+    @SuppressWarnings("unused")
+    public void validationApi(String api) {
+        configuration.setValidationApi(api);
+    }
+
+    // DSL: springBootVersion("3.2.0") — legacy fallback (used when validationApi is not set)
     @SuppressWarnings("unused")
     public void springBootVersion(String version) {
         configuration.setSpringBootVersion(version);

--- a/src/main/groovy/ru/yojo/codegen/YojoGenerateTask.java
+++ b/src/main/groovy/ru/yojo/codegen/YojoGenerateTask.java
@@ -5,6 +5,7 @@ import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.TaskAction;
 import ru.yojo.codegen.context.YojoContext;
+import ru.yojo.codegen.domain.ValidationApi;
 import ru.yojo.codegen.generator.YojoGenerator;
 import ru.yojo.codegen.meta.Configuration;
 
@@ -32,7 +33,10 @@ public abstract class YojoGenerateTask extends DefaultTask {
         }
 
         YojoContext context = new YojoContext();
-        context.setSpringBootVersion(config.getSpringBootVersion());
+        context.setValidationApi(config.getValidationApi() != null
+                ? ValidationApi.valueOf(config.getValidationApi().toUpperCase())
+                : null);
+        context.setSpringBootVersion(config.getSpringBootVersion());  // legacy fallback
         context.setLombokProperties(config.toLombokProperties());
         context.setSpecificationProperties(config.toSpecList());
 

--- a/src/main/groovy/ru/yojo/codegen/YojoPlugin.java
+++ b/src/main/groovy/ru/yojo/codegen/YojoPlugin.java
@@ -2,26 +2,80 @@ package ru.yojo.codegen;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.tasks.TaskProvider;
 
+/**
+ * Gradle plugin that generates Java DTOs from AsyncAPI specifications using Yojo.
+ * <p>
+ * Each named configuration registers its own task {@code generateClasses<Name>}
+ * (e.g. {@code generateClassesMain}, {@code generateClassesEvents}).
+ * A lifecycle task {@code generateClasses} aggregates all of them, so a single
+ * {@code dependsOn("generateClasses")} always works regardless of config count.
+ * <p>
+ * Usage:
+ * <pre>
+ * yojo {
+ *     configurations {
+ *         create("main") {
+ *             specificationProperties {
+ *                 register("api") { ... }
+ *             }
+ *         }
+ *     }
+ * }
+ * </pre>
+ */
 @SuppressWarnings("unused")
 public class YojoPlugin implements Plugin<Project> {
 
+    static final String LIFECYCLE_TASK_NAME = "generateClasses";
+    static final String TASK_GROUP = "YOJO";
+    static final String EXTENSION_NAME = "yojo";
+
     @Override
     public void apply(Project project) {
-        YojoExtension yojoExtension = project.getExtensions().create("yojo", YojoExtension.class);
+        YojoExtension yojoExtension = project.getExtensions().create(EXTENSION_NAME, YojoExtension.class);
+
+        // Register lifecycle task that aggregates all config-specific tasks.
+        // Users wire dependsOn("generateClasses") once regardless of config count.
+        TaskProvider<Task> lifecycleTask = project.getTasks().register(LIFECYCLE_TASK_NAME, task -> {
+            task.setDescription("Generates Yojo sources from all configured specifications.");
+            task.setGroup(TASK_GROUP);
+        });
 
         yojoExtension.getConfigurations().configureEach(config -> {
-            String taskName = "generateClasses";
-            TaskProvider<YojoGenerateTask> yojo = project.getTasks().register(taskName, YojoGenerateTask.class, config, project.getLayout());
-            yojo.configure(task -> {
-                task.setDescription(String.format("Generates the Yojo sources from the %s Yojo configuration.", config.getName()));
-                task.setGroup("YOJO");
+            String taskName = deriveTaskName(config.getName());
+            TaskProvider<YojoGenerateTask> configTask = project.getTasks().register(
+                    taskName,
+                    YojoGenerateTask.class,
+                    config,
+                    project.getLayout()
+            );
+            configTask.configure(task -> {
+                task.setDescription("Generates Yojo sources from the '%s' configuration."
+                        .formatted(config.getName()));
+                task.setGroup(TASK_GROUP);
             });
+
+            // Wire each config task into the lifecycle
+            lifecycleTask.configure(task -> task.dependsOn(configTask));
         });
     }
 
-    public static String capitalize(String s) {
-        return s == null || s.isEmpty() ? s : Character.toUpperCase(s.charAt(0)) + s.substring(1);
+    /**
+     * Derives a deterministic task name from the configuration name.
+     * <ul>
+     *   <li>{@code "main"} → {@code "generateClassesMain"}</li>
+     *   <li>{@code "events"} → {@code "generateClassesEvents"}</li>
+     * </ul>
+     */
+    static String deriveTaskName(String configName) {
+        return LIFECYCLE_TASK_NAME + capitalize(configName);
+    }
+
+    private static String capitalize(String s) {
+        if (s == null || s.isEmpty()) return s;
+        return Character.toUpperCase(s.charAt(0)) + s.substring(1);
     }
 }

--- a/src/main/groovy/ru/yojo/codegen/meta/Configuration.java
+++ b/src/main/groovy/ru/yojo/codegen/meta/Configuration.java
@@ -13,10 +13,10 @@ import ru.yojo.codegen.domain.lombok.LombokProperties;
 import javax.inject.Inject;
 
 public class Configuration {
-    private ProjectLayout layout;
-
     @Input
-    private String springBootVersion;
+    private String validationApi;           // "JAKARTA" or "JAVAX" — preferred way
+    @Input
+    private String springBootVersion;       // legacy fallback, used when validationApi is null
     @Input
     private Lombok lombok = new Lombok();
 
@@ -25,7 +25,6 @@ public class Configuration {
 
     @Inject
     public Configuration(ProjectLayout layout, ObjectFactory objects) {
-        this.layout = layout;
         this.specificationProperties = objects.domainObjectContainer(
                 SpecificationProperties.class,
                 name -> objects.newInstance(SpecificationProperties.class, name)
@@ -45,6 +44,14 @@ public class Configuration {
     }
 
     // -- Getters
+    public String getValidationApi() {
+        return validationApi;
+    }
+
+    public void setValidationApi(String validationApi) {
+        this.validationApi = validationApi;
+    }
+
     public String getSpringBootVersion() {
         return springBootVersion;
     }

--- a/src/main/groovy/ru/yojo/codegen/meta/SpecificationProperties.java
+++ b/src/main/groovy/ru/yojo/codegen/meta/SpecificationProperties.java
@@ -17,9 +17,8 @@ public class SpecificationProperties {
     }
 
     public String getName() { return name; }
-    public String getSpecName() { return specName != null ? specName : name; }
+    public String getSpecName() { return specName; }
 
-    // геттеры/сеттеры для остального
     public String getInputDirectory() { return inputDirectory; }
     public void setInputDirectory(String inputDirectory) { this.inputDirectory = inputDirectory; }
 

--- a/src/test/groovy/ru/yojo/codegen/YojoGenerateTaskTest.java
+++ b/src/test/groovy/ru/yojo/codegen/YojoGenerateTaskTest.java
@@ -5,17 +5,18 @@ import org.gradle.api.Task;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class YojoGenerateTaskTest {
 
     @Test
-    void testMultiSpecConfiguration() {
+    void testSingleMainConfiguration() {
         Project project = ProjectBuilder.builder().build();
-        YojoExtension ext = project.getExtensions().create("yojo", YojoExtension.class);
+        var ext = project.getExtensions().create("yojo", YojoExtension.class);
 
         ext.getConfigurations().create("main", config -> {
             config.getConfiguration().getSpecificationProperties().create("test.yaml", sp -> {
+                sp.setSpecName("test.yaml");
                 sp.setInputDirectory("./src/test/resources/example/contract");
                 sp.setOutputDirectory("./build/generated");
                 sp.setPackageLocation("test.api");
@@ -29,5 +30,29 @@ class YojoGenerateTaskTest {
                 project.getLayout()
         );
         assertNotNull(task);
+    }
+
+    @Test
+    void testAllConfigurationTaskNames() {
+        assertEquals("generateClassesMain", YojoPlugin.deriveTaskName("main"));
+        assertEquals("generateClassesMain", YojoPlugin.deriveTaskName("Main"));
+        assertEquals("generateClassesEvents", YojoPlugin.deriveTaskName("events"));
+        assertEquals("generateClassesApi", YojoPlugin.deriveTaskName("api"));
+    }
+
+    @Test
+    void testSpecNameDefaultsToNull() {
+        Project project = ProjectBuilder.builder().build();
+        var ext = project.getExtensions().create("yojo", YojoExtension.class);
+
+        ext.getConfigurations().create("main", config -> {
+            config.getConfiguration().getSpecificationProperties().create("mySpec", sp -> {
+                // specName intentionally not set — should be null, not fallback to "mySpec"
+            });
+        });
+
+        var spec = ext.getConfigurations().getByName("main")
+                .getConfiguration().getSpecificationProperties().getByName("mySpec");
+        assertNull(spec.getSpecName(), "specName should be null when not explicitly set");
     }
 }

--- a/src/test/groovy/ru/yojo/codegen/YojoIntegrationTest.groovy
+++ b/src/test/groovy/ru/yojo/codegen/YojoIntegrationTest.groovy
@@ -52,13 +52,21 @@ class YojoIntegrationTest {
             config.configuration.lombok.enable = false
         }
 
-        // 3. Получаем и **корректно выполняем** задачу
-        def task = project.tasks.findByName("generateClasses")
-        assertNotNull(task, "Task 'generateClasses' should be registered by YojoPlugin")
+        // 3. Проверяем lifecycle task generateClasses
+        def lifecycleTask = project.tasks.findByName("generateClasses")
+        assertNotNull(lifecycleTask, "Lifecycle task 'generateClasses' should be registered")
+        assertEquals("YOJO", lifecycleTask.group, "Lifecycle task should belong to YOJO group")
+
+        // 3b. Находим и выполняем конфигурационную задачу для main
+        def configTask = project.tasks.findByName("generateClassesMain")
+        assertNotNull(configTask, "Config task 'generateClassesMain' should be registered for 'main' config")
+        assertEquals("YOJO", configTask.group, "Config task should belong to YOJO group")
+        assertTrue(lifecycleTask.getTaskDependencies().getDependencies(lifecycleTask).contains(configTask),
+                "Lifecycle task should depend on generateClassesMain")
 
         // ✅ ПРАВИЛЬНО: вызов через actions
-        task.actions.each { action ->
-            action.execute(task)
+        configTask.actions.each { action ->
+            action.execute(configTask)
         }
 
         // 4. Проверяем результат


### PR DESCRIPTION
- Refactoring: fixed multi-config task naming (per-config named tasks)
- Added lifecycle task 'generateClasses' aggregating all config tasks
- Added validationApi('JAKARTA'/'JAVAX') DSL option (springBootVersion kept as legacy)
- Removed dead code, unused params, confusing specName fallback
- README: complete rewrite with clear plugin DSL vs YAML features separation
- Tests: added deriveTaskName, lifecycle task, specName defaults coverage
- .gitignore: added standard ignores
- Plugin 1.2.0 -> 1.3.0, generator 4.0.0 -> 4.3.0